### PR TITLE
github-webhook detection fix again

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACL.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACL.java
@@ -88,7 +88,7 @@ public class GithubRequireOrganizationMembershipACL extends ACL {
 					String requestURI = Stapler.getCurrentRequest()
 							.getOriginalRequestURI();
 
-					if (requestURI.matches("/github-webhook$") && allowGithubWebHookPermission == true) {
+					if (requestURI.matches("*/github-webhook/?$") && allowGithubWebHookPermission == true) {
 
 							// allow if the permission was configured.
 


### PR DESCRIPTION
Again propose the github-webhook detection fix. 
After testing on real environment there was find that the regexp is not correct.
