### PR TITLE
adding support for changing the github uri (eg for Github Enterprise Edition)

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GithubSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubSecurityRealm.java
@@ -68,19 +68,28 @@ import org.springframework.dao.DataAccessException;
  */
 public class GithubSecurityRealm extends SecurityRealm {
 
+	private String githubUri;
 	private String clientID;
 	private String clientSecret;
 
 	@DataBoundConstructor
-	public GithubSecurityRealm(String clientID, String clientSecret) {
+	public GithubSecurityRealm(String githubUri, String clientID, String clientSecret) {
 		super();
 
+		this.githubUri = Util.fixEmptyAndTrim(githubUri);
 		this.clientID = Util.fixEmptyAndTrim(clientID);
 		this.clientSecret = Util.fixEmptyAndTrim(clientSecret);
 		
 	}
 
 	/**
+	 * @return the uri to Github (varies for Github Enterprise Edition)
+	 */
+	public String getGithubUri() {
+		return githubUri;
+	}
+	
+     /**
 	 * @return the clientID
 	 */
 	public String getClientID() {
@@ -106,7 +115,7 @@ public class GithubSecurityRealm extends SecurityRealm {
 			throws IOException {
 
 		return new HttpRedirect(
-				"https://github.com/login/oauth/authorize?client_id="
+				githubUri + "/login/oauth/authorize?client_id="
 						+ clientID);
 		
 		// we only need the readonly scope to get the group membership info.
@@ -128,7 +137,7 @@ public class GithubSecurityRealm extends SecurityRealm {
 		Log.info("test");
 
 		HttpPost httpost = new HttpPost(
-				"https://github.com/login/oauth/access_token?" + "client_id="
+				githubUri + "/login/oauth/access_token?" + "client_id="
 						+ clientID + "&" + "client_secret=" + clientSecret
 						+ "&" + "code=" + code);
 

--- a/src/main/resources/org/jenkinsci/plugins/GithubSecurityRealm/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/GithubSecurityRealm/config.jelly
@@ -4,6 +4,9 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 	<f:section title="Global Github OAuth Settings" >
+		<f:entry title="Github Uri"  field="githubUri" >
+			<f:textbox default="https://github.com" />
+		</f:entry>
 		<f:entry title="Client ID"  field="clientID" >
 			<f:textbox />
 		</f:entry>


### PR DESCRIPTION
My company is trying out a copy of "Github Enterprise" (which is freaking awesome!).  This is a surgical change to allow overriding the github url to github.mycompany.com.  For the 99% case, the uri still defaults to https://github.com

  ---  Dave
