### PR TITLE
fixed for new github applications url

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A. GithubSecurityRealm:
 
 This handles the authentication and acquisition of the github oauth token for the connecting user.
 
-This takes the client id and client secret from the application registration here: https://github.com/account/applications/new
+This takes the client id and client secret from the application registration here: https://github.com/settings/applications/new
 
 The entry should look like this:
 

--- a/src/main/webapp/help/help-security-realm.html
+++ b/src/main/webapp/help/help-security-realm.html
@@ -3,7 +3,7 @@
  Authentication requires a valid OAuth application to be registered with github.com.
  <br/>
  Using your github account you can create a new application registration using this link:
-  <a href="https://github.com/account/applications/new">https://github.com/account/applications/new</a>
+  <a href="https://github.com/settings/applications/new">https://github.com/settings/applications/new</a>
   <br/>
   
 You can use any name you want but bear in mind this is what github will show to the users when they authenticate and authorize this plugin to act on their behalf. 

--- a/src/main/webapp/help/realm/client-id-help.html
+++ b/src/main/webapp/help/realm/client-id-help.html
@@ -1,3 +1,3 @@
 <div>
-The <b>Client ID</b> hash from the github application entry being configured.  See <a href="https://github.com/account/applications">https://github.com/account/applications</a>.
+The <b>Client ID</b> hash from the github application entry being configured.  See <a href="https://github.com/settings/applications">https://github.com/settings/applications</a>.
 </div>

--- a/src/main/webapp/help/realm/client-secret-help.html
+++ b/src/main/webapp/help/realm/client-secret-help.html
@@ -1,3 +1,3 @@
 <div>
-The <b>Client Secret</b> hash from the github application entry being configured.  See <a href="https://github.com/account/applications">https://github.com/account/applications</a>.
+The <b>Client Secret</b> hash from the github application entry being configured.  See <a href="https://github.com/settings/applications">https://github.com/settings/applications</a>.
 </div>


### PR DESCRIPTION
changed all occurrences of github.com/account/applications/new to github.com/settings/applications/new
