### PR TITLE
Restores basic api authentication functionality

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GithubSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubSecurityRealm.java
@@ -423,6 +423,9 @@ public class GithubSecurityRealm extends SecurityRealm {
 
 		GithubAuthenticationToken authToken =  (GithubAuthenticationToken) SecurityContextHolder.getContext().getAuthentication();
 		
+		if (authToken == null)
+			throw new UsernameNotFoundException("no known user: " + username);
+
 		try {
 			
 			GroupDetails group = loadGroupByGroupname(username);
@@ -455,6 +458,9 @@ public class GithubSecurityRealm extends SecurityRealm {
 		
 		GithubAuthenticationToken authToken =  (GithubAuthenticationToken) SecurityContextHolder.getContext().getAuthentication();
 		
+		if(authToken == null)
+			throw new UsernameNotFoundException("no known group: " + groupName);
+
 		try {
 			GHOrganization org = authToken.loadOrganization(groupName);
 			


### PR DESCRIPTION
I've prevented the unhandled exceptions and converted them
into standard exceptions. This way, it seems that the basic auth
filter catches the exceptions and validates the api token, solving issue #18
