### PR TITLE
Add security exception for /job/*/build and /job/*/buildWithParameters

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/GithubAuthorizationStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubAuthorizationStrategy.java
@@ -55,33 +55,34 @@ import org.kohsuke.stapler.Stapler;
 
 /**
  * @author mocleiri
- * 
- * 
- * 
+ *
+ *
+ *
  */
 public class GithubAuthorizationStrategy extends AuthorizationStrategy {
 
 	/**
 	 * @param allowAnonymousReadPermission
-	 * 
+	 *
 	 */
 	@DataBoundConstructor
 	public GithubAuthorizationStrategy(String adminUserNames,
 			boolean authenticatedUserReadPermission, String organizationNames,
 			boolean allowGithubWebHookPermission, boolean allowCcTrayPermission,
-			boolean allowAnonymousReadPermission) {
+			boolean allowBuildPermission, boolean allowAnonymousReadPermission) {
 		super();
 
 		rootACL = new GithubRequireOrganizationMembershipACL(adminUserNames,
 				organizationNames, authenticatedUserReadPermission,
-				allowGithubWebHookPermission, allowCcTrayPermission, allowAnonymousReadPermission);
+				allowGithubWebHookPermission, allowCcTrayPermission,
+				allowBuildPermission, allowAnonymousReadPermission);
 	}
 
 	private final GithubRequireOrganizationMembershipACL rootACL;
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see hudson.security.AuthorizationStrategy#getRootACL()
 	 */
 	@Override
@@ -93,7 +94,7 @@ public class GithubAuthorizationStrategy extends AuthorizationStrategy {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see hudson.security.AuthorizationStrategy#getGroups()
 	 */
 	@Override
@@ -145,7 +146,16 @@ public class GithubAuthorizationStrategy extends AuthorizationStrategy {
 		return rootACL.isAllowCcTrayPermission();
 	}
 
-	
+
+	/**
+	 * @return
+	 * @see org.jenkinsci.plugins.GithubRequireOrganizationMembershipACL#isAllowBuildPermission()
+	 */
+	public boolean isAllowBuildPermission() {
+		return rootACL.isAllowBuildPermission();
+	}
+
+
 	/**
 	 * @return
 	 * @see org.jenkinsci.plugins.GithubRequireOrganizationMembershipACL#isAllowAnonymousReadPermission()

--- a/src/main/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACL.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACL.java
@@ -40,7 +40,7 @@ import org.kohsuke.stapler.Stapler;
 
 /**
  * @author Mike
- * 
+ *
  */
 public class GithubRequireOrganizationMembershipACL extends ACL {
 
@@ -51,12 +51,13 @@ public class GithubRequireOrganizationMembershipACL extends ACL {
 	private final List<String> adminUserNameList;
 	private final boolean authenticatedUserReadPermission;
 	private final boolean allowGithubWebHookPermission;
-    private final boolean allowCcTrayPermission;
-    private final boolean allowAnonymousReadPermission;
+  private final boolean allowCcTrayPermission;
+	private final boolean allowBuildPermission;
+  private final boolean allowAnonymousReadPermission;
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see hudson.security.ACL#hasPermission(org.acegisecurity.Authentication,
 	 * hudson.security.Permission)
 	 */
@@ -163,6 +164,21 @@ public class GithubRequireOrganizationMembershipACL extends ACL {
 					// else fall through to false.
 				}
 
+				if (allowBuildPermission &&
+						(currentUriPathIncludes("/build")) ||
+						(currentUriPathIncludes("/buildWithParameters"))) {
+
+					// allow if the permission was configured.
+
+					if (checkReadPermission(permission)) {
+						log.info("Granting READ access for /build url: "
+								+ requestURI());
+						return true;
+					}
+
+					// else fall through to false.
+				}
+
 				log.finer("Denying anonymous READ permission to url: "
 						+ requestURI());
 				return false;
@@ -188,6 +204,10 @@ public class GithubRequireOrganizationMembershipACL extends ACL {
         return URI.create(requestURI()).getPath().equals(basePath + specificPath);
     }
 
+    private boolean currentUriPathIncludes( String specificPath ) {
+        return URI.create(requestURI()).getPath().indexOf(specificPath) >= 0;
+    }
+
     private String requestURI() {
         return Stapler.getCurrentRequest().getOriginalRequestURI();
     }
@@ -211,12 +231,14 @@ public class GithubRequireOrganizationMembershipACL extends ACL {
 	public GithubRequireOrganizationMembershipACL(String adminUserNames,
 			String organizationNames, boolean authenticatedUserReadPermission,
 			boolean allowGithubWebHookPermission,
-            boolean allowCcTrayPermission,
+      boolean allowCcTrayPermission,
+      boolean allowBuildPermission,
 			boolean allowAnonymousReadPermission) {
 		super();
 		this.authenticatedUserReadPermission = authenticatedUserReadPermission;
 		this.allowGithubWebHookPermission = allowGithubWebHookPermission;
         this.allowCcTrayPermission = allowCcTrayPermission;
+        this.allowBuildPermission = allowBuildPermission;
         this.allowAnonymousReadPermission = allowAnonymousReadPermission;
 
 		this.adminUserNameList = new LinkedList<String>();
@@ -253,10 +275,13 @@ public class GithubRequireOrganizationMembershipACL extends ACL {
 		return allowGithubWebHookPermission;
 	}
 
-    public boolean isAllowCcTrayPermission() {
-        return allowCcTrayPermission;
-    }
+  public boolean isAllowCcTrayPermission() {
+    return allowCcTrayPermission;
+  }
 
+  public boolean isAllowBuildPermission() {
+  	return allowBuildPermission;
+  }
     /**
 	 * @return the allowAnonymousReadPermission
 	 */

--- a/src/main/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACL.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACL.java
@@ -165,8 +165,8 @@ public class GithubRequireOrganizationMembershipACL extends ACL {
 				}
 
 				if (allowBuildPermission &&
-						(currentUriPathIncludes("/build")) ||
-						(currentUriPathIncludes("/buildWithParameters"))) {
+						(currentUriPathMatches("\\/job\\/[^\\/]*\\/build$")) ||
+						(currentUriPathMatches("\\/job\\/[^\\/]*\\/buildWithParameters$"))) {
 
 					// allow if the permission was configured.
 
@@ -204,8 +204,8 @@ public class GithubRequireOrganizationMembershipACL extends ACL {
         return URI.create(requestURI()).getPath().equals(basePath + specificPath);
     }
 
-    private boolean currentUriPathIncludes( String specificPath ) {
-        return URI.create(requestURI()).getPath().indexOf(specificPath) >= 0;
+    private boolean currentUriPathMatches( String expression ) {
+        return URI.create(requestURI()).getPath().matches(expression);
     }
 
     private String requestURI() {

--- a/src/main/resources/org/jenkinsci/plugins/GithubAuthorizationStrategy/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/GithubAuthorizationStrategy/config.jelly
@@ -1,5 +1,5 @@
 <!--
- 
+
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
@@ -7,26 +7,30 @@
 		<f:entry title="Admin User Names"  field="adminUserNames" help="/plugin/github-oauth/help/auth/admin-user-names-help.html" >
 			<f:textbox />
 		</f:entry>
-		
+
 		<f:entry title="Participant in Organization"  field="organizationNames" help="/plugin/github-oauth/help/auth/organization-names-help.html">
 			<f:textbox />
 		</f:entry>
-		
+
 		 <f:entry title="Grant READ permissions to all Authenticated Users" field="authenticatedUserReadPermission" help="/plugin/github-oauth/help/auth/grant-read-to-authenticated-help.html">
  		<f:checkbox />
  		</f:entry>
- 		
+
  		 <f:entry title="Grant READ permissions for /github-webhook" field="allowGithubWebHookPermission" help="/plugin/github-oauth/help/auth/grant-read-to-github-webhook-help.html">
  		<f:checkbox />
  		</f:entry>
- 		
+
  		 <f:entry title="Grant READ permissions for /cc.xml" field="allowCcTrayPermission" help="/plugin/github-oauth/help/auth/grant-read-to-cctray-help.html">
+ 		<f:checkbox />
+ 		</f:entry>
+
+ 		 <f:entry title="Grant READ permissions for /job/*/build" field="allowBuildPermission" help="/plugin/github-oauth/help/auth/grant-read-to-build-help.html">
  		<f:checkbox />
  		</f:entry>
 
  		 <f:entry title="Grant READ permissions for Anonymous Users" field="allowAnonymousReadPermission" help="/plugin/github-oauth/help/auth/grant-read-to-anonymous-help.html">
  		<f:checkbox />
  		</f:entry>
-		
+
 	</f:section>
 </j:jelly>

--- a/src/main/webapp/help/auth/grant-read-to-build-help.html
+++ b/src/main/webapp/help/auth/grant-read-to-build-help.html
@@ -1,0 +1,3 @@
+<div>
+Allow unauthenticated access to /build and /buildWithParameters for any job.
+</div>


### PR DESCRIPTION
This pull request adds a configuration option to expose the `/build` and `/buildWithParameters` URLs for all jobs.

In order to trigger builds remotely (via "Build Triggers"), an external client needs to make a request to `/job/:job-name/build` (or `/job/:job-name/buildWithParameters`). This request is protected by a secret `token` parameter, so exposing the URL publicly should be minimally dangerous.
