### PR TITLE
added support for the embeddable-build-status plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ This defines:
 4. Check box to allow anonymous users READ permission for the /github-webhook.  
 This only has meaning if the github-plugin is installed and the remote github repository post commit hook has been setup accordingly.
 
+5. Check box to allow anonymous users READ permission for the /job/*/badge/icon [embeddable build status icon](https://wiki.jenkins-ci.org/display/JENKINS/Embeddable+Build+Status+Plugin).
+
 The plugin works but there are still some areas like form validation that need work.  And some other cases where exceptions are thrown when perhaps there is a better way.
 
 Notes:

--- a/src/main/java/org/jenkinsci/plugins/GithubAuthorizationStrategy.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubAuthorizationStrategy.java
@@ -69,12 +69,12 @@ public class GithubAuthorizationStrategy extends AuthorizationStrategy {
 	public GithubAuthorizationStrategy(String adminUserNames,
 			boolean authenticatedUserReadPermission, String organizationNames,
 			boolean allowGithubWebHookPermission, boolean allowCcTrayPermission,
-			boolean allowAnonymousReadPermission) {
+            boolean allowEmbeddableBuildStatusIconPermission, boolean allowAnonymousReadPermission) {
 		super();
 
 		rootACL = new GithubRequireOrganizationMembershipACL(adminUserNames,
 				organizationNames, authenticatedUserReadPermission,
-				allowGithubWebHookPermission, allowCcTrayPermission, allowAnonymousReadPermission);
+				allowGithubWebHookPermission, allowCcTrayPermission, allowEmbeddableBuildStatusIconPermission, allowAnonymousReadPermission);
 	}
 
 	private final GithubRequireOrganizationMembershipACL rootACL;
@@ -145,7 +145,14 @@ public class GithubAuthorizationStrategy extends AuthorizationStrategy {
 		return rootACL.isAllowCcTrayPermission();
 	}
 
-	
+	/**
+	 * @return
+	 * @see org.jenkinsci.plugins.GithubRequireOrganizationMembershipACL#isAllowEmbeddableBuildStatusIconPermission()
+	 */
+	public boolean isAllowEmbeddableBuildStatusIconPermission() {
+		return rootACL.isAllowEmbeddableBuildStatusIconPermission();
+	}
+
 	/**
 	 * @return
 	 * @see org.jenkinsci.plugins.GithubRequireOrganizationMembershipACL#isAllowAnonymousReadPermission()
@@ -153,7 +160,6 @@ public class GithubAuthorizationStrategy extends AuthorizationStrategy {
 	public boolean isAllowAnonymousReadPermission() {
 		return rootACL.isAllowAnonymousReadPermission();
 	}
-
 
 	@Extension
 	public static final class DescriptorImpl extends

--- a/src/main/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACL.java
+++ b/src/main/java/org/jenkinsci/plugins/GithubRequireOrganizationMembershipACL.java
@@ -34,7 +34,6 @@ import java.net.URI;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.logging.Logger;
-import java.util.regex.Pattern;
 
 import jenkins.model.Jenkins;
 import org.acegisecurity.Authentication;

--- a/src/main/resources/org/jenkinsci/plugins/GithubAuthorizationStrategy/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/GithubAuthorizationStrategy/config.jelly
@@ -20,6 +20,10 @@
  		<f:checkbox />
  		</f:entry>
  		
+ 		 <f:entry title="Grant READ permissions for /job/*/badge/icon" field="allowEmbeddableBuildStatusIconPermission" help="/plugin/github-oauth/help/auth/grant-read-to-embedable-build-status-icon-help.html">
+ 		<f:checkbox />
+ 		</f:entry>
+
  		 <f:entry title="Grant READ permissions for /cc.xml" field="allowCcTrayPermission" help="/plugin/github-oauth/help/auth/grant-read-to-cctray-help.html">
  		<f:checkbox />
  		</f:entry>

--- a/src/main/webapp/help/auth/grant-read-to-embedable-build-status-icon-help.html
+++ b/src/main/webapp/help/auth/grant-read-to-embedable-build-status-icon-help.html
@@ -1,0 +1,10 @@
+<div>
+    <p>
+    The <a href="https://wiki.jenkins-ci.org/display/JENKINS/Embeddable+Build+Status+Plugin">Embeddable Build Status Plugin</a>
+    allows Jenkins to expose the current status of your build as an image in a fixed URL. You can put this URL into other sites
+    (such as GitHub README) so that people can see the current state of the build.
+    </p>
+    <p>
+    By enabling this permission you grant anonymous external READ access to the <b>/job/*/badge/icon</b> URLs so that the icon is accessible.
+    </p>
+</div>

--- a/src/main/webapp/help/auth/grant-read-to-embedable-build-status-icon-help.html
+++ b/src/main/webapp/help/auth/grant-read-to-embedable-build-status-icon-help.html
@@ -1,10 +1,15 @@
 <div>
     <p>
-    The <a href="https://wiki.jenkins-ci.org/display/JENKINS/Embeddable+Build+Status+Plugin">Embeddable Build Status Plugin</a>
-    allows Jenkins to expose the current status of your build as an image in a fixed URL. You can put this URL into other sites
-    (such as GitHub README) so that people can see the current state of the build.
+        The <a href="https://wiki.jenkins-ci.org/display/JENKINS/Embeddable+Build+Status+Plugin">Embeddable Build Status
+        Plugin</a>
+        allows Jenkins to expose the current status of your build as an image in a fixed URL. You can put this URL into
+        other sites
+        (such as GitHub README) so that people can see the current state of the build.
     </p>
+
     <p>
-    By enabling this permission you grant anonymous external READ access to the <b>/job/*/badge/icon</b> URLs so that the icon is accessible.
+        By enabling this permission you grant anonymous external READ access to the <b>/job/*/badge/icon</b> URLs so
+        that the icon is accessible.<br/>
+        e.g. http://localhost:8080/jenkins/job/jobName/badge/icon
     </p>
 </div>


### PR DESCRIPTION
The embeddable-build-status plugin provides an embeddable status icon, which can be used on external sites (for example a GitHub README.md). However, to allow this the github-oauth-plugin needs to allow requests made to this icon.

A new configuration checkbox, help file and business logic has been added to allow such an exception.

See the readme for the [grails-uploadr plugin](https://github.com/4np/grails-uploadr#build-status) for a demonstration.
